### PR TITLE
Fix: day change calls refresh properly.

### DIFF
--- a/js/ikterminal.js
+++ b/js/ikterminal.js
@@ -77,7 +77,7 @@ const startIKDay = function() {
     var now = new Date();
     var timeToPastMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, 0, 0, 5, 0) - now;  // 5 Seconds for time differences
     setTimeout(function() {
-        refreshById('ikday');
+        refreshById('ikday')();
         startIKDay();
     }, timeToPastMidnight);
 }


### PR DESCRIPTION
It seems I must have hit refresh during my last tests, as I now figured out that refreshById's callback was not called properly again... This time I tested it by changing the system clock back and forth.