### PR TITLE
Using media query instead of screen.width or screen.innerWidth 

### DIFF
--- a/js/ikterminal.js
+++ b/js/ikterminal.js
@@ -117,7 +117,7 @@ const loader = function() {
     startIKDay();
     refreshBySchedule('schedule', 60);
     refreshBySchedule('shoutbox_container', 5);
-    if (screen.width >= 1024) {
+    if (window.matchMedia("screen and (min-width: 1024px)")) {
         refreshBySchedule('impressions', 20);
     }
     document.getElementById('shoutboxmessage').addEventListener('onkeydown', sendShoutbox);


### PR DESCRIPTION
...to disable impressions.
See https://github.com/jspricke/ik-infoscreen/pull/18#issuecomment-370441947.