### PR TITLE
Watchlist

### DIFF
--- a/css/detail.css
+++ b/css/detail.css
@@ -52,3 +52,26 @@
 body {
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
+
+#favcb {
+    display: none;
+}
+
+#favcb + label {
+	background-color: #fafafa;
+	border: 1px solid #cacece;
+	padding: 15px;
+	border-radius: 3px;
+	display: inline-block;
+	position: relative;
+    float: right;
+}
+
+#favcb:checked + label:after {
+	font-size: 28px;
+	position: absolute;
+    left: 0;
+    top: 0;
+	color: #99a1a7;
+	content: '\1F31F';
+}

--- a/css/detail.css
+++ b/css/detail.css
@@ -70,8 +70,8 @@ body {
 #favcb:checked + label:after {
 	font-size: 28px;
 	position: absolute;
-    left: 0;
-    top: 0;
-	color: #99a1a7;
-	content: '\1F31F';
+    left: 7px;
+    top: -3px;
+	color: crimson;
+	content: '\2665';
 }

--- a/css/style.css
+++ b/css/style.css
@@ -39,6 +39,10 @@ img {  /* Never stretch the layout because of the impression image. */
     margin-top: 0.1em;
 }
 
+.event input {
+    float: right;
+}
+
 footer {
     position: absolute;
     right: 0;
@@ -246,6 +250,12 @@ a:hover {
 #timeslot_active, .event.active {
     border-radius: 0.5em;
     background-color: #e0f2f7;
+}
+
+.event a:hover {
+    text-decoration: none;
+    background: #efefef;
+    border-radius: 0.5em;
 }
 
 .event a span {

--- a/css/style.css
+++ b/css/style.css
@@ -89,6 +89,12 @@ footer ul {
     font-weight: bold;
 }
 
+#daytoggler div {
+    font-size: 0.85em;
+    padding: 0.1em;
+    float: left;
+}
+
 /* Bigger small screens have a 2-column schedule */
 @media (min-width:600px) {
     header { /* reset width for h1 s in header */

--- a/css/style.css
+++ b/css/style.css
@@ -139,7 +139,7 @@ footer ul {
         grid-column-end: 3;
     }
 
-    #daytoggler button:before {
+    #daytoggler button:not(:first-child):before {
         content: "Day ";
     }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -62,7 +62,7 @@ footer ul {
 
 #tools {
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
     flex-flow: row wrap;
 }
 
@@ -71,26 +71,31 @@ footer ul {
     justify-content: center;
 }
 
-#daytoggle a {
+#daytoggle a, #tools button {
     display: block;
     color: black;
     text-decoration: none;
     margin: 0;
     padding: 0.2em 1.2em;
-    font-size: 0.8em;
+    font-size: 9pt;
     border: 1px outset #e0f2f7;
     background-color: #e0f2f7;
+    float: left;
 }
 
-#daytoggle a:first-of-type {
+#daytoggle a:first-child, #favport button:first-child {
     border-radius: 0.5em 0 0 0.5em;
 }
 
-#daytoggle a:last-child {
+#daytoggle a:last-child, #favport button:last-child {
     border-radius: 0 0.5em 0.5em 0;
 }
 
-#daytoggle a.disabled {
+#favtoggle button {
+    border-radius: 0.5em;
+}
+
+#tools .disabled {
     border: 1px inset #e0f2f7;
     color: gray;
 }
@@ -100,15 +105,6 @@ footer ul {
     font-weight: bold;
 }
 
-#favtoggle {
-    font-size: 0.85em;
-    padding: 0.1em;
-}
-
-#favport {
-    font-size: 0.85em;
-    padding: 0.1em;
-}
 
 /* Bigger small screens have a 2-column schedule */
 @media (min-width:600px) {
@@ -128,6 +124,7 @@ footer ul {
     #tools {
         grid-column-start: 1;
         grid-column-end: 2;
+        justify-content: space-between;
     }
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -60,39 +60,54 @@ footer ul {
     margin: 0.5em 0 0.5em 0;
 }
 
-#daytoggler {
-    text-align: center;
+#tools {
+    display: flex;
+    justify-content: space-between;
+    flex-flow: row wrap;
 }
 
-#daytoggler button {
+#daytoggle {
+    display: flex;
+    justify-content: center;
+}
+
+#daytoggle a {
+    display: block;
+    color: black;
+    text-decoration: none;
     margin: 0;
     padding: 0.2em 1.2em;
+    font-size: 0.8em;
     border: 1px outset #e0f2f7;
     background-color: #e0f2f7;
 }
 
-#daytoggler button:first-of-type {
+#daytoggle a:first-of-type {
     border-radius: 0.5em 0 0 0.5em;
 }
 
-#daytoggler button:last-child {
+#daytoggle a:last-child {
     border-radius: 0 0.5em 0.5em 0;
 }
 
-#daytoggler button[disabled="disabled"] {
+#daytoggle a.disabled {
     border: 1px inset #e0f2f7;
     color: gray;
 }
 
-#daytoggler button.active {
+#daytoggle a.active {
     color: rgb(51, 122, 183);
     font-weight: bold;
 }
 
-#daytoggler div {
+#favtoggle {
     font-size: 0.85em;
     padding: 0.1em;
-    float: left;
+}
+
+#favport {
+    font-size: 0.85em;
+    padding: 0.1em;
 }
 
 /* Bigger small screens have a 2-column schedule */
@@ -110,7 +125,7 @@ footer ul {
         grid-column-gap: 0.15em;
     }
 
-    #daytoggler {
+    #tools {
         grid-column-start: 1;
         grid-column-end: 2;
     }
@@ -140,12 +155,12 @@ footer ul {
         grid-template-columns: repeat(3, 1fr);
     }
 
-    #daytoggler {
+    #tools {
         grid-column-start: 1;
         grid-column-end: 3;
     }
 
-    #daytoggler button:before {
+    #daytoggle a:before {
         content: "Day ";
     }
 }
@@ -156,7 +171,7 @@ footer ul {
         grid-template-columns: repeat(3, 1fr);
     }
 
-    #daytoggler {
+    #tools {
         grid-column-start: 1;
         grid-column-end: 4;
     }

--- a/css/style.css
+++ b/css/style.css
@@ -254,7 +254,7 @@ a:hover {
 
 .event a:hover {
     text-decoration: none;
-    background: #efefef;
+    background: #cfcfcf;
     border-radius: 0.5em;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -71,7 +71,7 @@ footer ul {
     background-color: #e0f2f7;
 }
 
-#daytoggler button:first-child {
+#daytoggler button:first-of-type {
     border-radius: 0.5em 0 0 0.5em;
 }
 
@@ -139,7 +139,7 @@ footer ul {
         grid-column-end: 3;
     }
 
-    #daytoggler button:not(:first-child):before {
+    #daytoggler button:before {
         content: "Day ";
     }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -75,7 +75,7 @@ footer ul {
     display: block;
     color: black;
     text-decoration: none;
-    margin: 0;
+    margin: 0 0 5px 0;
     padding: 0.2em 1.2em;
     font-size: 9pt;
     border: 1px outset #e0f2f7;

--- a/details.py
+++ b/details.py
@@ -97,11 +97,22 @@ def create_details(json):
 <head>
     <meta charset="utf-8">
     <title>{json['title'].replace('<b>', '').replace('</b>', '')}</title>
+    <script type="text/javascript" src="/js/ikterminal.js"></script>
     <link rel="stylesheet" type="text/css" href="/css/detail.css">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <noscript>
+        <style>
+        #favcb + label {{
+            display: none;
+        }}
+        </style>
+    </noscript>
 </head>
-<body>
-    <h1>{json['title']}</h1>
+<body onload="document.getElementById('favcb').checked = getFavorites().has({json['collection_id']});"
+>
+    <h1>{json['title']}
+    <input type="checkbox" id="favcb" onclick="toggleFavorite({json['collection_id']});" /><label for="favcb"></label>
+    </h1>
     <article>
         {clean_section(json['attributes']['description'], 'Description')}
         {clean_section(json['attributes']['objectives'], 'Objectives')}

--- a/functions.php
+++ b/functions.php
@@ -144,16 +144,17 @@ function event_group_list_item($event, $start_time, $evening_time, $now) {
         $sessioncount = '';
     }
 
-    printf('<div class="event%s">' .
+    printf('<div class="event%s" data-id="%s">' .
                '<a href="./details/detail%s.html">' .
                    '<span class="lecture_id" style="background-color: %s;">%s</span>' .
-                   '<span class="lecturer">%s%s</span>' .
+                   '<span class="lecturer">%s%s<input type="checkbox" value="%s" /></span>' .
                    '<span class="location" style="background-color: %s;">%s</span>' .
                    '<span class="title">%s</span>' .
                '</a>' .
            '</div>',
            is_active_event($now, $evt_start->format('H:i'), $evt_end->format('H:i')) ? ' active' : '',
-           $id, $color, $time ? $time : $abbr, $instructor, $sessioncount, $color, $location, $title);
+           $id, $id, $color, $time ? $time : $abbr, $instructor, $sessioncount,
+           $id, $color, $location, $title);
 }
 
 function is_active_timeslot($now, $start, $end) {

--- a/functions.php
+++ b/functions.php
@@ -170,10 +170,10 @@ function is_active_event($now, $start, $end) {
 
 function create_swapDay_button($day) {
     global $CURRENT_DAY, $VIEW_DAY;
-    printf('<button onclick="swapDay(%s);"%s%s>%s</button>',
-        $day == $CURRENT_DAY ? '' : $day,
-        $day == $CURRENT_DAY ? ' class="active"' : '',
-        $day == $VIEW_DAY ? ' disabled="disabled"' : '',
+    printf('<a href="%s" class="%s%s">%s</a>',
+        $day == $CURRENT_DAY ? '/' : ('/?day=' . $day),
+        $day == $CURRENT_DAY ? 'active' : '',
+        $day == $VIEW_DAY ? ' disabled' : '',
         $day);
 }
 

--- a/functions.php
+++ b/functions.php
@@ -147,14 +147,14 @@ function event_group_list_item($event, $start_time, $evening_time, $now) {
     printf('<div class="event%s" data-id="%s">' .
                '<a href="./details/detail%s.html">' .
                    '<span class="lecture_id" style="background-color: %s;">%s</span>' .
-                   '<span class="lecturer">%s%s<input type="checkbox" value="%s" /></span>' .
+                   '<span class="lecturer"><input type="checkbox" value="%s" />%s%s</span>' .
                    '<span class="location" style="background-color: %s;">%s</span>' .
                    '<span class="title">%s</span>' .
                '</a>' .
            '</div>',
            is_active_event($now, $evt_start->format('H:i'), $evt_end->format('H:i')) ? ' active' : '',
-           $id, $id, $color, $time ? $time : $abbr, $instructor, $sessioncount,
-           $id, $color, $location, $title);
+           $id, $id, $color, $time ? $time : $abbr, $id, $instructor, $sessioncount,
+           $color, $location, $title);
 }
 
 function is_active_timeslot($now, $start, $end) {

--- a/index.php
+++ b/index.php
@@ -52,7 +52,7 @@
 
             <section id="impressions">
                 <a href="/images">
-                    <img src="<?php echo $path . $img ?>" alt="IK Impression" id="impression" />
+                    <img src="<?= $path . $img ?>" alt="IK Impression" id="impression" />
                 </a>
             </section>
 

--- a/index.php
+++ b/index.php
@@ -16,6 +16,13 @@
                 }
             </style>
         </noscript>
+        <?php if (isset($_GET["hidetools"])): ?>
+        <style>
+            #tools, #schedule input {
+                display: none;
+            }
+        </style>
+        <?php endif ?>
     </head>
     <body onload="loader();" id="body">
 

--- a/index.php
+++ b/index.php
@@ -31,6 +31,7 @@
             </section>
 
             <section id="daytoggler">
+                <button onclick="toggleFavoriteVisibility(); return false;">Toggle</button>
                 <?php for ($i = 1; $i <= $IK_DAYS; ++$i)  {
                     create_swapDay_button($i);
                 } ?>

--- a/index.php
+++ b/index.php
@@ -6,6 +6,13 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <script type="text/javascript" src="/js/ikterminal.js"></script>
         <link rel="stylesheet" type="text/css" href="/css/style.css">
+        <noscript>
+            <style>
+                #schedule input, #daytoggler label, #favtoggler {
+                    display: none;
+                }
+            </style>
+        </noscript>
     </head>
     <body onload="loader();" id="body">
 

--- a/index.php
+++ b/index.php
@@ -38,7 +38,7 @@
             </section>
 
             <section id="daytoggler">
-                <label for="favtoggler">Favorites</label><input type="checkbox" id="favtoggler" onclick="toggleFavoriteVisibility();" />
+                <div><input type="checkbox" id="favtoggler" onclick="toggleFavoriteVisibility();" /><label for="favtoggler">Favorites</label></div>
                 <?php for ($i = 1; $i <= $IK_DAYS; ++$i)  {
                     create_swapDay_button($i);
                 } ?>

--- a/index.php
+++ b/index.php
@@ -54,6 +54,7 @@
                 <div id="favport">
                     <button id="export">Export favorites</button>
                     <button id="import">Import favorites</button>
+                    <button id="clear">Clear favorites</button>
                 </div>
             </section>
 

--- a/index.php
+++ b/index.php
@@ -42,8 +42,7 @@
 
             <section id="tools">
                 <div id="favtoggle">
-                    <input type="checkbox" id="favtoggler" onclick="toggleFavoriteVisibility();" />
-                    <label for="favtoggler">Favorites</label>
+                    <button id="favtoggler">Toggle favorites</button>
                 </div>
 
                 <div id="daytoggle">

--- a/index.php
+++ b/index.php
@@ -8,8 +8,11 @@
         <link rel="stylesheet" type="text/css" href="/css/style.css">
         <noscript>
             <style>
-                #schedule input, #daytoggler label, #favtoggler {
+                #schedule input, #favtoggle, #favport {
                     display: none;
+                }
+                #tools {
+                    justify-content: center;
                 }
             </style>
         </noscript>
@@ -37,11 +40,22 @@
                 <?php endforeach ?>
             </section>
 
-            <section id="daytoggler">
-                <div><input type="checkbox" id="favtoggler" onclick="toggleFavoriteVisibility();" /><label for="favtoggler">Favorites</label></div>
+            <section id="tools">
+                <div id="favtoggle">
+                    <input type="checkbox" id="favtoggler" onclick="toggleFavoriteVisibility();" />
+                    <label for="favtoggler">Favorites</label>
+                </div>
+
+                <div id="daytoggle">
                 <?php for ($i = 1; $i <= $IK_DAYS; ++$i)  {
                     create_swapDay_button($i);
                 } ?>
+                </div>
+
+                <div id="favport">
+                    <button id="export">Export favorites</button>
+                    <button id="import">Import favorites</button>
+                </div>
             </section>
 
             <section class="announcements">

--- a/index.php
+++ b/index.php
@@ -31,7 +31,7 @@
             </section>
 
             <section id="daytoggler">
-                <button onclick="toggleFavoriteVisibility(); return false;">Toggle</button>
+                <label for="favtoggler">Favorites</label><input type="checkbox" id="favtoggler" onclick="toggleFavoriteVisibility();" />
                 <?php for ($i = 1; $i <= $IK_DAYS; ++$i)  {
                     create_swapDay_button($i);
                 } ?>

--- a/js/ikterminal.js
+++ b/js/ikterminal.js
@@ -171,7 +171,6 @@ const toggleFavorite = function(id) {
         ids.add(id);
     }
     setFavorites(ids);
-    updateFavorites();
 }
 
 /**
@@ -251,6 +250,7 @@ const addFavoriteEventListeners = function() {
         input.addEventListener('click', evt => {
             evt.preventDefault();
             toggleFavorite(parseInt(evt.target.value));
+            updateFavorites();
         });
     }
 }
@@ -287,6 +287,8 @@ const loader = function() {
     }).observe(document.getElementById('schedule'), {childList: true} );
     document.getElementById('shoutboxmessage').addEventListener('onkeydown', sendShoutbox);
     document.getElementById('shoutboxform').addEventListener('submit', submitShoutbox);
+
+    window.addEventListener('focus', evt => updateFavorites());
 
     scrollToActive();
 };

--- a/js/ikterminal.js
+++ b/js/ikterminal.js
@@ -112,6 +112,49 @@ const swapDay = function(day) {
     window.location.href = url;
 }
 
+const toggleFavorite = function(id) {
+    // TODO: toggle button images, style buttons
+    var storage = window.localStorage;
+    var ids = new Set();
+    if (storage.getItem('course_ids') !== null) {
+        JSON.parse(storage.getItem('course_ids')).forEach(
+            (e) => ids.add(e)
+        );
+    }
+    if (ids.has(id)) {
+        ids.delete(id);
+    } else {
+        ids.add(id);
+    }
+    storage.setItem('course_ids', JSON.stringify(Array.from(ids)));
+    console.log(storage);
+}
+
+const toggleFavoriteVisibility = function() {
+    // TODO: store current toggling state and reverse if needed
+    // Add ability to share/transfer across devices
+    var storage = window.localStorage;
+    var ids = new Set();
+    if (storage.getItem('course_ids') !== null) {
+        JSON.parse(storage.getItem('course_ids')).forEach(
+            (e) => ids.add(e)
+        );
+    }
+
+    var events = document.getElementById('schedule').getElementsByClassName('event');
+    for (var i = 0; i < events.length; ++i) {
+        if (ids.has(parseInt(events[i].getAttribute('data-id')))) {
+            events[i].style.display = 'block';
+        } else {
+            events[i].style.display = 'none';
+        }
+    }
+}
+
+const clearFavorites = function() {
+    window.localStorage.removeItem('course_ids');
+}
+
 const loader = function() {
     startTime();
     startIKDay();

--- a/js/ikterminal.js
+++ b/js/ikterminal.js
@@ -1,3 +1,5 @@
+/** *** Refreshes *** **/
+
 const contentFromHTMLById = function(html, id) {
     var dom = document.createElement('html');
     dom.innerHTML = html;
@@ -29,6 +31,9 @@ const refreshBySchedule = function(id, interval) {
     setInterval(refreshById(id), interval * 1000)
 }
 
+
+/** *** Shoutbox *** **/
+
 const sendShoutbox = function(evt) {
     if (evt.keyCode == 13) {
         document.getElementById('shoutboxform').submit();
@@ -37,11 +42,11 @@ const sendShoutbox = function(evt) {
 
 const submitShoutbox = function(evt) {
     evt.preventDefault();
-    sendData();
+    sendShoutboxData();
     return false;
 }
 
-const sendData = function() {
+const sendShoutboxData = function() {
     var XHR = new XMLHttpRequest();
 
     XHR.addEventListener("load", function(event) {
@@ -57,6 +62,9 @@ const sendData = function() {
 
     XHR.send(new FormData(document.getElementById('shoutboxform')));
 }
+
+
+/** *** Date and Time *** **/
 
 const startTime = function() {
 	var today = new Date();
@@ -82,6 +90,9 @@ const startIKDay = function() {
     }, timeToPastMidnight);
 }
 
+
+/** *** Scrolling *** **/
+
 const scrollToActive = function() {
     var active = document.getElementById('timeslot_active');
 
@@ -103,6 +114,9 @@ const scrollToActive = function() {
         window.scrollTo(0, active.offsetTop);
     }
 }
+
+
+/** *** Preview *** **/
 
 const swapDay = function(day) {
     var url = document.URL.split('?')[0];
@@ -154,6 +168,9 @@ const toggleFavoriteVisibility = function() {
 const clearFavorites = function() {
     window.localStorage.removeItem('course_ids');
 }
+
+
+/** *** Entry point *** **/
 
 const loader = function() {
     startTime();

--- a/js/ikterminal.js
+++ b/js/ikterminal.js
@@ -116,17 +116,6 @@ const scrollToActive = function() {
 }
 
 
-/** *** Preview *** **/
-
-const swapDay = function(day) {
-    var url = document.URL.split('?')[0];
-    if (day) {
-        url += '?day=' + day;
-    }
-    window.location.href = url;
-}
-
-
 /** *** Favorites *** **/
 
 /**
@@ -264,6 +253,28 @@ const updateFavorites = function() {
     setTimeout(updateCheckboxes, 10);
 }
 
+/**
+ * Copies the current list of favorites to the clipboard
+ * and shows a short notification about the process.
+ */
+const exportFavorites = function() {
+    var ids = getFavorites();
+    prompt('Copy this and paste it on another device.', Array.from(ids).join(','));
+}
+
+/**
+ * Prompts the user to paste the list from the export.
+ * Updates the favorites.
+ */
+const importFavorites = function() {
+    var favorites = prompt('Insert your exported favorites. Leave blank to keep your current favorites.', '');
+    if (favorites) {
+        var ids = new Set(favorites.split(',').map(i => parseInt(i)));
+        setFavorites(ids);
+        updateFavorites();
+    }
+}
+
 
 /** *** Entry point *** **/
 
@@ -287,6 +298,8 @@ const loader = function() {
     }).observe(document.getElementById('schedule'), {childList: true} );
     document.getElementById('shoutboxmessage').addEventListener('onkeydown', sendShoutbox);
     document.getElementById('shoutboxform').addEventListener('submit', submitShoutbox);
+    document.getElementById('export').addEventListener('click', exportFavorites);
+    document.getElementById('import').addEventListener('click', importFavorites);
 
     window.addEventListener('focus', evt => updateFavorites());
 

--- a/js/ikterminal.js
+++ b/js/ikterminal.js
@@ -264,7 +264,7 @@ const updateFavorites = function() {
  */
 const exportFavorites = function() {
     var ids = getFavorites();
-    prompt('Copy this and paste it on another device.', Array.from(ids).join(','));
+    prompt('Copy this and paste it on another device.', Array.from(ids).sort().join(','));
 }
 
 /**

--- a/js/ikterminal.js
+++ b/js/ikterminal.js
@@ -209,6 +209,8 @@ const applyFavoriteVisibility = function() {
             events[i].style.display = 'none';
         }
     }
+
+    document.getElementById('favtoggler').checked = visible != 1;
 }
 
 /**

--- a/js/ikterminal.js
+++ b/js/ikterminal.js
@@ -164,7 +164,6 @@ const setFavorites = function(ids) {
  *     id The id to add or remove.
  */
 const toggleFavorite = function(id) {
-    console.log('Toggling ' + id);
     var ids = getFavorites();
     if (ids.has(id)) {
         ids.delete(id);
@@ -227,7 +226,6 @@ const clearFavorites = function() {
  * Updates the checkboxes. For selected events they are checked, for others not.
  */
 const updateCheckboxes = function() {
-    console.log('update updateCheckboxes');
     var ids = getFavorites();
 
     var events = document.getElementById('schedule').getElementsByClassName('event');
@@ -245,7 +243,6 @@ const updateCheckboxes = function() {
  * Adds eventlisteners to all checkboxes inside the schedule.
  */
 const addFavoriteEventListeners = function() {
-    console.log('Adding favorite listeners.');
     var ids = getFavorites();
     var inputs = document.getElementById('schedule').getElementsByTagName('input');
     for (var input of inputs) {

--- a/js/ikterminal.js
+++ b/js/ikterminal.js
@@ -208,13 +208,19 @@ const applyFavoriteVisibility = function() {
 
 /**
  * Cleans up the local storage.
+ *
+ * First, prompts the user to type "yes" to clear it to avoid accidental clearings.
+ *
  * Removes the items course_ids and courses_visible. Applies the favorite
  * visibility, effectively showing all events.
  */
 const clearFavorites = function() {
-    window.localStorage.removeItem('course_ids');
-    window.localStorage.removeItem('courses_visible');
-    updateFavorites();
+    var response = prompt('Type "yes" to clear the favorites.', 'no');
+    if (response == 'yes') {
+        window.localStorage.removeItem('course_ids');
+        window.localStorage.removeItem('courses_visible');
+        updateFavorites();
+    }
 }
 
 /**
@@ -306,6 +312,7 @@ const loader = function() {
     document.getElementById('favtoggler').addEventListener('click', toggleFavoriteVisibility);
     document.getElementById('export').addEventListener('click', exportFavorites);
     document.getElementById('import').addEventListener('click', importFavorites);
+    document.getElementById('clear').addEventListener('click', clearFavorites);
     window.addEventListener('focus', evt => updateFavorites());
 
     scrollToActive();

--- a/js/ikterminal.js
+++ b/js/ikterminal.js
@@ -198,7 +198,12 @@ const applyFavoriteVisibility = function() {
         }
     }
 
-    document.getElementById('favtoggler').checked = visible != 1;
+    var toggler = document.getElementById('favtoggler');
+    if (visible != 1) {
+        toggler.classList.add('disabled');
+    } else {
+        toggler.classList.remove('disabled');
+    }
 }
 
 /**
@@ -298,9 +303,9 @@ const loader = function() {
     }).observe(document.getElementById('schedule'), {childList: true} );
     document.getElementById('shoutboxmessage').addEventListener('onkeydown', sendShoutbox);
     document.getElementById('shoutboxform').addEventListener('submit', submitShoutbox);
+    document.getElementById('favtoggler').addEventListener('click', toggleFavoriteVisibility);
     document.getElementById('export').addEventListener('click', exportFavorites);
     document.getElementById('import').addEventListener('click', importFavorites);
-
     window.addEventListener('focus', evt => updateFavorites());
 
     scrollToActive();


### PR DESCRIPTION
This feature adds a local (i.e. device-local using localStorage) watchlist for courses.
- Adds checkboxes to the lectures.
- Selecting a checkbox adds a course to the watchlist, unselected removes it.
- Toggling between "favorites" and non-favorites using a button hides unselected courses.
- Favorites and view setting are localStorage-persistent.
- Changing the schedule list links to not trigger on checkbox clicks.
- Changing the schedule list links to feel like "big buttons" instead of textual links by using a gray background instead of blue underlines.
- Disables this feature if no javascript is available.
- Preview works without javascript.
- Import/Export via prompts, passing a simple list of course ids: `47,51,52`. This has to be copied and transfered manually, but avoids the trouble of detecting URLs and import intends etc.
- The daytoggler bar is now a `tools` bar and contains the favorite toggle and the import export buttons.
- The details pages also feature a button to star the lectures / indicate their favorite status.

Main page with only favorites and hover effect:
<img width="800" alt="Main page with only favorites and hover effec" src="https://user-images.githubusercontent.com/1836815/37094896-a9dc728c-2214-11e8-8838-d8ad70f0f27c.png">

Details page with favorite star (if unfavorited, the box is empty):
<img width="800" alt="Details page with favorite star" src="https://user-images.githubusercontent.com/1836815/37094775-48b71296-2214-11e8-92a5-173ceb79c598.png">

~I am still thinking about how to better position/style the toggle button, especially to also represent the current state. But this has to wait until tomorrow, just wanted to give you an opportunity to give some feedback on the feature: Do we want it? Or not?~

~P.S.: I was thinking about sharing etc. via a link - but that quickly seems to be out of scope for now, so device-local is the best I will be able to offer in time.~