### PR TITLE
Preview works without JS.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -57,30 +57,35 @@ footer ul {
 }
 
 #daytoggler {
-    text-align: center;
+    display: flex;
+    justify-content: center;
 }
 
-#daytoggler button {
+#daytoggler a {
+    display: block;
+    color: black;
+    text-decoration: none;
     margin: 0;
     padding: 0.2em 1.2em;
+    font-size: 0.8em;
     border: 1px outset #e0f2f7;
     background-color: #e0f2f7;
 }
 
-#daytoggler button:first-child {
+#daytoggler a:first-of-type {
     border-radius: 0.5em 0 0 0.5em;
 }
 
-#daytoggler button:last-child {
+#daytoggler a:last-child {
     border-radius: 0 0.5em 0.5em 0;
 }
 
-#daytoggler button[disabled="disabled"] {
+#daytoggler a.disabled {
     border: 1px inset #e0f2f7;
     color: gray;
 }
 
-#daytoggler button.active {
+#daytoggler a.active {
     color: rgb(51, 122, 183);
     font-weight: bold;
 }
@@ -135,7 +140,7 @@ footer ul {
         grid-column-end: 3;
     }
 
-    #daytoggler button:before {
+    #daytoggler a:before {
         content: "Day ";
     }
 }

--- a/functions.php
+++ b/functions.php
@@ -169,10 +169,10 @@ function is_active_event($now, $start, $end) {
 
 function create_swapDay_button($day) {
     global $CURRENT_DAY, $VIEW_DAY;
-    printf('<button onclick="swapDay(%s);"%s%s>%s</button>',
-        $day == $CURRENT_DAY ? '' : $day,
-        $day == $CURRENT_DAY ? ' class="active"' : '',
-        $day == $VIEW_DAY ? ' disabled="disabled"' : '',
+    printf('<a href="%s" class="%s%s">%s</a>',
+        $day == $CURRENT_DAY ? '/' : ('/?day=' . $day),
+        $day == $CURRENT_DAY ? 'active' : '',
+        $day == $VIEW_DAY ? ' disabled' : '',
         $day);
 }
 

--- a/js/ikterminal.js
+++ b/js/ikterminal.js
@@ -104,14 +104,6 @@ const scrollToActive = function() {
     }
 }
 
-const swapDay = function(day) {
-    var url = document.URL.split('?')[0];
-    if (day) {
-        url += '?day=' + day;
-    }
-    window.location.href = url;
-}
-
 const loader = function() {
     startTime();
     startIKDay();


### PR DESCRIPTION
As I was working on #20 and hiding the functionality on devices without JS, I decided to make the preview work without JS. JS was originally intended to just reload the schedule, but since I never did that, this simple solution should suffice.